### PR TITLE
Specify nightly resolver in install/run instructions

### DIFF
--- a/content/install/linux.md
+++ b/content/install/linux.md
@@ -28,7 +28,7 @@ Either:
 ..or:
 
  * [Install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install). Stack is a build tool for Haskell / Clash projects;
- * Run `stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl` to compile `HelloWorld.hs` to VHDL.
+ * Run `stack exec --package clash-ghc --resolver=nightly -- clash HelloWorld.hs --vhdl` to compile `HelloWorld.hs` to VHDL.
 
 ### Option B. Setup a project
 To setup a new project, [install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install) and run:

--- a/content/install/macos.md
+++ b/content/install/macos.md
@@ -28,7 +28,7 @@ Depending on your goals, you might want to simply run Clash on its own, or setup
 The following compiles a file `HelloWorld.hs` to VHDL:
 
 ```
-stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl
+stack exec --package clash-ghc --resolver=nightly -- clash HelloWorld.hs --vhdl
 ```
 
 ### Option B. Setup a project

--- a/content/install/windows.md
+++ b/content/install/windows.md
@@ -26,7 +26,7 @@ Depending on your goals, you might want to simply run Clash on its own, or setup
 The following compiles a file `HelloWorld.hs` to VHDL:
 
 ```
-stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl
+stack exec --package clash-ghc --resolver=nightly -- clash HelloWorld.hs --vhdl
 ```
 
 ### Option B. Setup a project


### PR DESCRIPTION
Without it, I get the following errors:
```
$ stack exec --package clash-ghc -- clashi

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for clash-ghc-1.4.0:
    clash-lib must match ==1.4.0, but the stack configuration has no specified version  (latest matching version
              is 1.4.0)
    clash-prelude must match ==1.4.0, but the stack configuration has no specified version  (latest matching version
                  is 1.4.0)
    concurrent-supply must match >=0.1.7 && <0.2, but the stack configuration has no specified version  (latest
                      matching version is 0.1.8)
needed since clash-ghc is a build target.

Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps
    in /home/christiaan/.stack/global-project/stack.yaml:

- clash-lib-1.4.0@sha256:5357c189e290af3c8ef4af33e11da7d62c28835edd4e9b6a714862b52d605a3e,13192
- clash-prelude-1.4.0@sha256:75cfb8f59f830ed7399563ab59bb3c964b6e970d8c4aacf1535c7d7f7dbb1f6f,16070
- concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
```