### PR TITLE
Remove snap install instructions

### DIFF
--- a/content/install/linux.md
+++ b/content/install/linux.md
@@ -20,13 +20,6 @@ Depending on your goals, you might want to simply run Clash on its own, or setup
 
 ### Option A. Run Clash on its own
 
-Either:
-
- * Install Clash using `snap`: see [snapcraft.io/clash](https://snapcraft.io/clash);
- * Run `clash HelloWorld.hs --vhdl` to compile `HelloWorld.hs` to VHDL.
-
-..or:
-
  * [Install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install). Stack is a build tool for Haskell / Clash projects;
  * Run `stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl` to compile `HelloWorld.hs` to VHDL.
 


### PR DESCRIPTION
Snap makes it very hard to install specific versions of the compiler,
and silently upgrades users to the newest version. While this is
probably a good choice for a lot of desktop applications, this is an
awful property for compilers. Furthermore, we've since:

 * Made a starter project that makes "installing" Clash obsolete
 * Have discovered that we can easily run Clash in non-project mode
   with Stack

I believe we should therefore not advertise Snap installs anymore.