### PR TITLE
Set 'no-referrer' for auto-loaded contents from external domains

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,9 +8,9 @@ weight: -50
 
 Clash is an [open-source](https://github.com/clash-lang/clash-compiler) project, licensed under the permissive [BSD2](https://raw.githubusercontent.com/clash-lang/clash-compiler/master/LICENSE) license, and actively maintained by [QBayLogic](https://qbaylogic.com/). The Clash project is a [Haskell Foundation](https://haskell.foundation/affiliates/) affiliated project.
 
-[![pipeline status](https://gitlab.com/clash-lang/clash-compiler/badges/master/pipeline.svg)](https://gitlab.com/clash-lang/clash-compiler/-/pipelines?scope=finished&ref=master)
-[![Hackage](https://img.shields.io/hackage/v/clash-ghc.svg)](https://hackage.haskell.org/package/clash-ghc)
-[![activity](https://img.shields.io/github/commit-activity/m/clash-lang/clash-compiler)](https://github.com/clash-lang/clash-compiler/commits/master)
+<a href="https://gitlab.com/clash-lang/clash-compiler/commits/master"><img referrerpolicy="no-referrer" src="https://gitlab.com/clash-lang/clash-compiler/badges/master/pipeline.svg" alt="GitLab pipeline status badge"></a>
+<a href="https://hackage.haskell.org/package/clash-ghc"><img referrerpolicy="no-referrer" src="https://img.shields.io/hackage/v/clash-ghc.svg" alt="Hackage version badge"></a>
+<a href="https://github.com/clash-lang/clash-compiler/commits/master"><img referrerpolicy="no-referrer" src="https://img.shields.io/github/commit-activity/m/clash-lang/clash-compiler" alt="GitHub commit activity badge"></a>
 
 # Features
 <div class="cards250">

--- a/themes/mainroad/layouts/partials/header.html
+++ b/themes/mainroad/layouts/partials/header.html
@@ -23,7 +23,7 @@
 	{{- range .AlternativeOutputFormats }}
 	<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .RelPermalink | safeURL }}">
 	{{- end }}
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700">
+	<link referrerpolicy="no-referrer" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700">
 	<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 	<link rel="stylesheet" href="{{ "css/syntax.css" | relURL }}">
 	<script type="text/javascript" src="{{ "js/scripts.js" | relURL }}"></script>


### PR DESCRIPTION
Visitors currently notify Google CDN, GitLab, and Hackage on the main page. This PR sets 'no-referrer' to prevent that.