### PR TITLE
Improve installation instructions

### DIFF
--- a/content/install/linux.md
+++ b/content/install/linux.md
@@ -15,19 +15,27 @@ disable_comments: true
 
 <br/>
 
-# 2. Setup Clash
+# 2. Install Stack
+
+[Install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install). Stack is a build tool for Haskell / Clash projects.
+
+_If you want to setup a Clash project with Cabal instead, read [the starter project's README.md](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project)._
+
+# 3. Setup Clash
 Depending on your goals, you might want to simply run Clash on its own, or setup a proper project. The first one will get you up and running quickly and you won't have to learn build tools. However, you won't be able to use dependencies from [Hackage](https://hackage.haskell.org/) and it is harder to get a consistent build environment.
 
 ### Option A. Run Clash on its own
+The following compiles a file `HelloWorld.hs` to VHDL:
 
- * [Install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install). Stack is a build tool for Haskell / Clash projects;
- * Run `stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl` to compile `HelloWorld.hs` to VHDL.
+```
+stack exec --resolver lts-19 --package clash-ghc -- clash HelloWorld.hs --vhdl
+```
 
-### Option B. Setup a project
-To setup a new project, [install Stack](https://docs.haskellstack.org/en/stable/README/#how-to-install) and run:
+### Option B. Setup a starter project
+To setup a new project based on the provided starter projects, run:
 
 ```
 stack new my-clash-project clash-lang/simple
 ```
 
-This will create a new project called `my-clash-project` in a folder named the same. The folder will contain a `README.md` to get you up and running. Alternatively, you [can read it online](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project). People familiar with the Haskell ecosystem might prefer to use Cabal instead. To do so, [download the starter project as a zip](https://raw.githubusercontent.com/clash-lang/clash-starters/main/simple.zip) and follow the instructions in `README.md`.
+This will create a new project called `my-clash-project` in a folder named the same. The folder will contain a `README.md` to get you up and running. Alternatively, you [can read it online](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project). People familiar with the Haskell ecosystem might prefer to use Cabal instead. To do so, [download the starter project as a zip](https://raw.githubusercontent.com/clash-lang/clash-starters/main/simple.zip) and follow the instructions in [`README.md`](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project).

--- a/content/install/macos.md
+++ b/content/install/macos.md
@@ -28,14 +28,14 @@ Depending on your goals, you might want to simply run Clash on its own, or setup
 The following compiles a file `HelloWorld.hs` to VHDL:
 
 ```
-stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl
+stack exec --resolver lts-19 --package clash-ghc -- clash HelloWorld.hs --vhdl
 ```
 
-### Option B. Setup a project
-To setup a new project, run:
+### Option B. Setup a starter project
+To setup a new project based on the provided starter projects, run:
 
 ```
 stack new my-clash-project clash-lang/simple
 ```
 
-This will create a new project called `my-clash-project` in a folder named the same. The folder will contain a `README.md` to get you up and running. Alternatively, you [can read it online](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project). People familiar with the Haskell ecosystem might prefer to use Cabal instead. To do so, [download the starter project as a zip](https://raw.githubusercontent.com/clash-lang/clash-starters/main/simple.zip) and follow the instructions in `README.md`.
+This will create a new project called `my-clash-project` in a folder named the same. The folder will contain a `README.md` to get you up and running. Alternatively, you [can read it online](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project). People familiar with the Haskell ecosystem might prefer to use Cabal instead. To do so, [download the starter project as a zip](https://raw.githubusercontent.com/clash-lang/clash-starters/main/simple.zip) and follow the instructions in [`README.md`](https://github.com/clash-lang/clash-starters/tree/main/simple#simple-starter-project).

--- a/content/install/windows.md
+++ b/content/install/windows.md
@@ -26,11 +26,11 @@ Depending on your goals, you might want to simply run Clash on its own, or setup
 The following compiles a file `HelloWorld.hs` to VHDL:
 
 ```
-stack exec --package clash-ghc -- clash HelloWorld.hs --vhdl
+stack exec --resolver lts-19 --package clash-ghc -- clash HelloWorld.hs --vhdl
 ```
 
-### Option B. Setup a project
-To setup a new project, run:
+### Option B. Setup a starter project
+To setup a new project based on the provided starter projects, run:
 
 ```
 stack new my-clash-project clash-lang/simple


### PR DESCRIPTION
* Note `--resolver lts-19` for Stack
* Harmonize the three OSes
* Emphasize the term "starter project" so people know what this site and the Clash.Tutorial module are talking about is one and the same concept.