### PR TITLE
Update the community links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -107,12 +107,10 @@ mmult mA mB = result
 # Open-source community
 Clash benefits from an active community.
 Whether you need a question answered or want to contribute to open-source features, browse the features below to make the most of Clash.
-We expect participants on these public forums to observe our [Guidelines for Respectful Communication](https://github.com/clash-lang/clash-compiler/blob/master/CODE_OF_CONDUCT.md).
 
-{{% fontawesome list-alt %}} [Mailing list](http://groups.google.com/group/clash-language)</br>
-{{% fontawesome ticket-alt %}} [Issue tracker](https://github.com/clash-lang/clash-compiler/issues)</br>
-{{% fontawesome slack-hash %}} [Slack: functionalprogramming.slack.com#clash](https://functionalprogramming.slack.com/archives/CPGMJFF50) (Invite yourself at [fpslack.com](https://fpslack.com))</br>
-{{% fontawesome slack-hash %}} [IRC (webchat): libera.chat#clash](https://web.libera.chat/#clash) (or [ircs://irc.libera.chat:6697/clash](ircs://irc.libera.chat:6697/clash) when you want to connect with a regular IRC client)
+{{% fontawesome list-alt %}} [Discourse: long form discussions and questions](https://clash-lang.discourse.group/)</br>
+{{% fontawesome slack-hash %}} [Slack: short form discussions and questions](https://functionalprogramming.slack.com/archives/CPGMJFF50) (Invite yourself at [fpslack.com](https://fpslack.com)) </br>
+{{% fontawesome ticket-alt %}} [Github: issue tracker](https://github.com/clash-lang/clash-compiler/issues)
 
 # Support
 If you need professional support from the [original developers](https://qbaylogic.com) of Clash, check out the [support plan]({{< ref "support" >}}).


### PR DESCRIPTION
Remove mailing list since it was pretty much inactive and annoying to use when you don't have a Google-backed email account. Replace it by a link to Discourse instead.

Remove IRC, since it was very much inactive. Most people now tend to use the Slack channel for fast communication.