### PR TITLE
Use buttons in OS picker

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -21,11 +21,13 @@ if (macosPlatforms.indexOf(platform) !== -1) {
   // Make a choice
 }
 </script>
+
 <link rel="stylesheet" href="/css/install.css">
 
 # 1. Choose your platform
-<div id="platform-select">
-  <a style="color:black;" href="/install/windows">{{% fontawesome windows-brands %}}</a>
-  <a style="color:black;" href="/install/macos">{{% fontawesome apple-brands %}}</a>
-  <a style="color:black;" href="/install/linux">{{% fontawesome linux-brands %}}</a>
+<div id="platform-select" class="button-group">
+    <a href="/install/windows"><button class="button">{{% fontawesome windows-brands %}}<br>Windows</button>
+    </a><a href="/install/macos"><button class="button">{{% fontawesome apple-brands %}}<br>macOS</button>
+    </a><a href="/install/linux"><button class="button">{{% fontawesome linux-brands %}}<br>Linux</button>
+    </a>
 </div>

--- a/content/install/linux.md
+++ b/content/install/linux.md
@@ -7,12 +7,14 @@ disable_comments: true
 <link rel="stylesheet" href="/css/install.css">
 
 # 1. Choose your platform
-<div id="platform-select">
-  <a style="color:black;" href="/install/windows">{{% fontawesome windows-brands %}}</a>
-  <a style="color:black;" href="/install/macos">{{% fontawesome apple-brands %}}</a>
-  <a href="/install/linux">{{% fontawesome linux-brands %}}</a>
+<div id="platform-select" class="button-group">
+    <a href="/install/windows"><button class="button">{{% fontawesome windows-brands %}}<br>Windows</button>
+    </a><a href="/install/macos"><button class="button">{{% fontawesome apple-brands %}}<br>macOS</button>
+    </a><a href="/install/linux"><button class="button active">{{% fontawesome linux-brands %}}<br>Linux</button>
+    </a>
 </div>
 
+<br/>
 <br/>
 
 # 2. Install Stack

--- a/content/install/macos.md
+++ b/content/install/macos.md
@@ -7,12 +7,14 @@ disable_comments: true
 <link rel="stylesheet" href="/css/install.css">
 
 # 1. Choose your platform
-<div id="platform-select">
-  <a style="color:black;" href="/install/windows">{{% fontawesome windows-brands %}}</a>
-  <a href="/install/macos">{{% fontawesome apple-brands %}}</a>
-  <a style="color:black;" href="/install/linux">{{% fontawesome linux-brands %}}</a>
+<div id="platform-select" class="button-group">
+    <a href="/install/windows"><button class="button">{{% fontawesome windows-brands %}}<br>Windows</button>
+    </a><a href="/install/macos"><button class="button active">{{% fontawesome apple-brands %}}<br>macOS</button>
+    </a><a href="/install/linux"><button class="button">{{% fontawesome linux-brands %}}<br>Linux</button>
+    </a>
 </div>
 
+<br/>
 <br/>
 
 # 2. Install Stack

--- a/content/install/windows.md
+++ b/content/install/windows.md
@@ -7,12 +7,14 @@ disable_comments: true
 <link rel="stylesheet" href="/css/install.css">
 
 # 1. Choose your platform
-<div id="platform-select">
-  <a href="/install/windows">{{% fontawesome windows-brands %}}</a>
-  <a style="color:black;" href="/install/macos">{{% fontawesome apple-brands %}}</a>
-  <a style="color:black;" href="/install/linux">{{% fontawesome linux-brands %}}</a>
+<div id="platform-select" class="button-group">
+    <a href="/install/windows"><button class="button active">{{% fontawesome windows-brands %}}<br>Windows</button>
+    </a><a href="/install/macos"><button class="button">{{% fontawesome apple-brands %}}<br>macOS</button>
+    </a><a href="/install/linux"><button class="button">{{% fontawesome linux-brands %}}<br>Linux</button>
+    </a>
 </div>
 
+<br/>
 <br/>
 
 # 2. Install Stack

--- a/static/css/install.css
+++ b/static/css/install.css
@@ -1,18 +1,31 @@
-#platform-select{
-  /* width: auto; */
-}
-
-#platform-select a,
-#platform-select a:hover
-{
-  text-decoration: none;
-}
-
-#platform-select .inline-svg{
-  width: 8em;
-  margin-right:3em;
-}
-
 .post__title, .list__item{
   display:none;
+}
+
+.button-group {
+    display: inline-flex;
+    border-radius: 5px;
+    overflow: hidden;
+    border: 1px solid #ccc;
+    height:70px;
+}
+
+.button {
+    padding: 10px 20px;
+    background-color: #f8f9fa;
+    border: none;
+    cursor: pointer;
+    transition: background 0.3s, color 0.3s;
+    font-size: 16px;
+    height:100%;
+}
+
+/* Add border between buttons */
+.button:not(:last-child) {
+    border-right: 1px solid #ccc;
+}
+
+.button:hover, .button.active {
+    background-color: #67ce59;
+    color: white;
 }


### PR DESCRIPTION
Users reported that in the current layout it isn't clear the OS images are buttons.

If it still isn't clear, we could think about removing the Javascript that auto-selects the OS based on the user's browser string. That would force them to click the buttons / notice that they are buttons.