### PR TITLE
Add border to buttons

### DIFF
--- a/static/css/install.css
+++ b/static/css/install.css
@@ -21,7 +21,7 @@
 }
 
 /* Add border between buttons */
-.button:not(:last-child) {
+.button-group a:not(:last-child) {
     border-right: 1px solid #ccc;
 }
 


### PR DESCRIPTION
Old:

![Screenshot 2025-02-09 at 09-51-32 Clash Install Clash on Linux](https://github.com/user-attachments/assets/4501cb60-4fbf-4610-b556-38da6a570683)

New:

![Screenshot 2025-02-09 at 09-51-23 Clash Install Clash on Linux](https://github.com/user-attachments/assets/485b7ab6-88d8-48aa-9ac1-cd167e3f0148)

----------

Really a bugfix. The `border-right` property didn't work after introducing `a`.