### PR TITLE
Install instructions `stack exec`: use LTS

### DIFF
--- a/content/install/linux.md
+++ b/content/install/linux.md
@@ -43,7 +43,7 @@ A starter project using Stack is the recommended way to use Clash, and is fully 
 The following compiles the file <a href="/code/ShortBlinker.hs" download>`ShortBlinker.hs`</a> to VHDL:
 
 ```
-stack exec --resolver nightly-2025-03-07 --package clash-ghc -- clash ShortBlinker.hs --vhdl
+stack exec --resolver lts-23.15 --package clash-ghc -- clash ShortBlinker.hs --vhdl
 ```
 
 The resulting HDL should be very similar to the following:

--- a/content/install/macos.md
+++ b/content/install/macos.md
@@ -43,7 +43,7 @@ A starter project using Stack is the recommended way to use Clash, and is fully 
 The following compiles the file <a href="/code/ShortBlinker.hs" download>`ShortBlinker.hs`</a> to VHDL:
 
 ```
-stack exec --resolver nightly-2025-03-07 --package clash-ghc -- clash ShortBlinker.hs --vhdl
+stack exec --resolver lts-23.15 --package clash-ghc -- clash ShortBlinker.hs --vhdl
 ```
 
 The resulting HDL should be very similar to the following:

--- a/content/install/windows.md
+++ b/content/install/windows.md
@@ -39,7 +39,7 @@ A starter project using Stack is the recommended way to use Clash, and is fully 
 The following compiles the file <a href="/code/ShortBlinker.hs" download>`ShortBlinker.hs`</a> to VHDL:
 
 ```
-stack exec --resolver nightly-2025-03-07 --package clash-ghc -- clash ShortBlinker.hs --vhdl
+stack exec --resolver lts-23.15 --package clash-ghc -- clash ShortBlinker.hs --vhdl
 ```
 
 The resulting HDL should be very similar to the following:


### PR DESCRIPTION
We are back in Stackage LTS! Change the `stack exec` line in the alternative installation methods to use an LTS version instead of a nightly.

The resulting VHDL, Verilog and SystemVerilog is bit-identical, so no need to adjust the example output files in `static/code/ShortBlinker`.