### PR TITLE
Show banner on home page

### DIFF
--- a/themes/mainroad/layouts/partials/header.html
+++ b/themes/mainroad/layouts/partials/header.html
@@ -35,7 +35,7 @@
 		<header class="header">
 			{{ partial "menu.html" . }}
 		</header>
-        {{ if eq .Title "Home" }}
+        {{ if .IsHome }}
         <div class="clash-banner">
             <div class="logo"></div>
             <div class="logo__inner">


### PR DESCRIPTION
PR #99 changed the title of the home page, breaking the conditional render of the home page banner. This commit changes the logic to a title-independent if statement.