### PR TITLE
Use dates in filenames to prevent merge "conflicts"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,12 @@ pagerSize = 10
   [services.disqus]
     shortname = ""
 
+[permalinks]
+  blog = "/blog/:year-:month-:day/:slug/"
+
+[frontmatter]
+  date = [":filename", ":default"]
+
 [markup.highlight]
 noClasses = false
 style = "tango"

--- a/content/blog/2018-07-09-matrix-multiplication.md
+++ b/content/blog/2018-07-09-matrix-multiplication.md
@@ -1,6 +1,7 @@
 ---
 title: "Matrix multiplication with Clash"
-date: "2018-07-09"
+aliases:
+  - /blog/0001-matrix-multiplication/
 description: "Building, restructuring, and pipelining matrix multiplication with Clash"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2018-07-25-systolic-arrays.md
+++ b/content/blog/2018-07-25-systolic-arrays.md
@@ -1,6 +1,7 @@
 ---
 title: "Building systolic arrays with Clash"
-date: "2018-07-25"
+aliases:
+  - /blog/0002-systolic-arrays/
 description: "Building a matrix multiplier using systolic arrays"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2019-06-07-zurihac-2019.md
+++ b/content/blog/2019-06-07-zurihac-2019.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash @ ZuriHac 2019"
-date: "2019-06-07"
+aliases:
+  - /blog/0003-zurihac-2019/
 description: "What it says on the tin"
 disable_comments: false
 author: "christiaanb"

--- a/content/blog/2019-06-10-undefined-values.md
+++ b/content/blog/2019-06-10-undefined-values.md
@@ -1,6 +1,7 @@
 ---
 title: "Undefined values, how do they work?"
-date: "2019-06-10"
+aliases:
+  - /blog/0004-undefined-values/
 description: "What are undefined values? Common pitfalls and available tooling to deal with them"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2019-06-11-synthesis-domain.md
+++ b/content/blog/2019-06-11-synthesis-domain.md
@@ -1,6 +1,7 @@
 ---
 title: "New feature: configurable initial values"
-date: "2019-06-11"
+aliases:
+  - /blog/0005-synthesis-domain/
 description: "A new way to represent signal domains allows us to track whether registers have initial values"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2021-06-01-deca-starter.md
+++ b/content/blog/2021-06-01-deca-starter.md
@@ -1,6 +1,7 @@
 ---
 title: "Getting started with Clash on the Arrow DECA devkit"
-date: "2021-06-01"
+aliases:
+  - /blog/0006-deca-starter/
 description: "Quickly set up a Clash project for the Arrow DECA development board"
 disable_comments: false
 author: "christiaanbaaij"

--- a/content/blog/2025-02-07-signals.md
+++ b/content/blog/2025-02-07-signals.md
@@ -1,6 +1,7 @@
 ---
 title: "Tricking Haskell into state: how Clash's Signal type works"
-date: "2025-02-07"
+aliases:
+  - /blog/0007-signals/
 description: "Going into detail on how the Signal type allows simulation of multiple, synchronous clock domains"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2025-12-23-clash-num.md
+++ b/content/blog/2025-12-23-clash-num.md
@@ -1,6 +1,7 @@
 ---
 title: "Putting a Clash Coat of Paint on Rust"
-date: "2025-12-23"
+aliases:
+  - /blog/0008-clash-num/
 description: "Reproducing Clash's numeric types in Rust"
 disable_comments: false
 author: "ryanslawson"

--- a/content/blog/2026-04-07-checked-literals.md
+++ b/content/blog/2026-04-07-checked-literals.md
@@ -1,6 +1,7 @@
 ---
 title: "Introducing checked-literals: compile-time bounds checking for numeric literals"
-date: "2026-04-07"
+aliases:
+  - /blog/0009-checked-literals/
 description: "A GHC plugin that turns out-of-range numeric literals into type errors"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/news/01-welcome.md
+++ b/content/news/01-welcome.md
@@ -10,7 +10,7 @@ mathjax: true
 ---
 
 Welcome to the new **Clash** website!
-While the [old website](http://clash-lang.github.io) served us well, we wanted to have support for a [blog]({{< ref "/blog" >}}): go check out our first two posts on [matrix multiplication]({{< ref "/blog/0001-matrix-multiplication" >}}) and [systolic arrays]({{< ref "/blog/0002-systolic-arrays" >}}).
+While the [old website](http://clash-lang.github.io) served us well, we wanted to have support for a [blog]({{< ref "/blog" >}}): go check out our first two posts on [matrix multiplication]({{< ref "/blog/2018-07-09-matrix-multiplication" >}}) and [systolic arrays]({{< ref "/blog/2018-07-25-systolic-arrays" >}}).
 
 We wanted a static website for all the usual reasons (speed, security, etc), and decided to use [hugo](https://gohugo.io) because:
 


### PR DESCRIPTION
Also: auto-dervive both dates and slugs from the filenames.

---------

For example, @marijn-qbaylogic had to go in an bump a number because my blogpost got merged earlier than his.

Also also; I'm trying to kill `/news`, which had some awkward merge "conflicts" too.