### PR TITLE
Merge 'Blog' into 'News'

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,13 +106,6 @@ unsafe= true
     weight = 30
 
   [[menu.main]]
-    identifier = "news"
-    name = "News"
-    pre = ""
-    url = "/news/"
-    weight = 20
-
-  [[menu.main]]
     identifier = "support"
     name = "Support plan"
     pre = ""

--- a/config.toml
+++ b/config.toml
@@ -106,6 +106,13 @@ unsafe= true
     weight = 30
 
   [[menu.main]]
+    identifier = "news"
+    name = "News"
+    pre = ""
+    url = "/categories/news/"
+    weight = 20
+
+  [[menu.main]]
     identifier = "support"
     name = "Support plan"
     pre = ""

--- a/content/blog/2018-11-20-welcome.md
+++ b/content/blog/2018-11-20-welcome.md
@@ -1,6 +1,7 @@
 ---
 title: "New website!"
-date: "2018-11-20"
+aliases:
+  - /news/01-welcome/
 description: "New version of clash-lang.org launched"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2018-11-20-welcome.md
+++ b/content/blog/2018-11-20-welcome.md
@@ -2,6 +2,8 @@
 title: "New website!"
 aliases:
   - /news/01-welcome/
+categories:
+  - "News"
 description: "New version of clash-lang.org launched"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2019-09-04-clash10.md
+++ b/content/blog/2019-09-04-clash10.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash 1.0 released!"
-date: "2019-09-04"
+aliases:
+  - /news/02-clash10/
 description: "10 years after the first public demonstration we finally release Clash 1.0"
 disable_comments: false
 author: "christiaanbaaij"

--- a/content/blog/2019-09-04-clash10.md
+++ b/content/blog/2019-09-04-clash10.md
@@ -2,6 +2,8 @@
 title: "Clash 1.0 released!"
 aliases:
   - /news/02-clash10/
+categories:
+  - "News"
 description: "10 years after the first public demonstration we finally release Clash 1.0"
 disable_comments: false
 author: "christiaanbaaij"

--- a/content/blog/2020-03-05-clash12.md
+++ b/content/blog/2020-03-05-clash12.md
@@ -2,6 +2,8 @@
 title: "Clash 1.2 released"
 aliases:
   - /news/03-clash12/
+categories:
+  - "News"
 description: "A lot of bug fixes"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2020-03-05-clash12.md
+++ b/content/blog/2020-03-05-clash12.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash 1.2 released"
-date: "2020-03-05"
+aliases:
+  - /news/03-clash12/
 description: "A lot of bug fixes"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2020-06-14-clash122.md
+++ b/content/blog/2020-06-14-clash122.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash 1.2.2 and future plans"
-date: "2020-06-14"
+aliases:
+  - /news/04-clash122/
 description: "Bugs bugs, and future plans"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2020-06-14-clash122.md
+++ b/content/blog/2020-06-14-clash122.md
@@ -2,6 +2,8 @@
 title: "Clash 1.2.2 and future plans"
 aliases:
   - /news/04-clash122/
+categories:
+  - "News"
 description: "Bugs bugs, and future plans"
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2021-03-12-clash14.md
+++ b/content/blog/2021-03-12-clash14.md
@@ -2,6 +2,8 @@
 title: "Clash 1.4 released"
 aliases:
   - /news/05-clash14/
+categories:
+  - "News"
 description: ""
 disable_comments: false
 author: "martijnbastiaan"

--- a/content/blog/2021-03-12-clash14.md
+++ b/content/blog/2021-03-12-clash14.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash 1.4 released"
-date: "2021-03-12"
+aliases:
+  - /news/05-clash14/
 description: ""
 disable_comments: false
 author: "martijnbastiaan"
@@ -12,7 +13,7 @@ mathjax: false
 
 Hi everyone!
 
-Although this release includes many small bug fixes and a few API changes, it mostly consists of internal changes to Clash. [As promised when releasing v1.2.2](https://clash-lang.org/news/04-clash122/) we've put a lot of effort in laying the groundwork for a partial evaluator. We believe this would make Clash an order of magnitude faster as well as more reliable when released. We've also refactored the way Clash generates unique identifiers which works around a number of issues with EDA tools our users have observed. Sadly, we haven't been able to make progress with Shake rules for Clash, promised in the same blog post.
+Although this release includes many small bug fixes and a few API changes, it mostly consists of internal changes to Clash. [As promised when releasing v1.2.2]({{< ref "/blog/2020-06-14-clash122" >}}) we've put a lot of effort in laying the groundwork for a partial evaluator. We believe this would make Clash an order of magnitude faster as well as more reliable when released. We've also refactored the way Clash generates unique identifiers which works around a number of issues with EDA tools our users have observed. Sadly, we haven't been able to make progress with Shake rules for Clash, promised in the same blog post.
 
 Apart from changes to Clash itself, we've continued to build the ecosystem itself:
 

--- a/content/blog/2026-04-07-checked-literals.md
+++ b/content/blog/2026-04-07-checked-literals.md
@@ -10,6 +10,7 @@ summary: "GHC's builtin overflow warnings are easy to bypass and don't work for 
 toc: true
 mathjax: false
 categories:
+  - "News"
   - "Tutorial"
 tags:
   - "Clash internals"

--- a/content/blog/2026-04-21-shockwaves.md
+++ b/content/blog/2026-04-21-shockwaves.md
@@ -7,7 +7,8 @@ authorbox: true # Optional, enable authorbox for specific post
 summary: "For years, debugging Clash designs in a waveform viewer has been a massive pain. After all, the waveform viewers we have were not designed with Clash in mind, and glady present us with unintelligible binary values. But those times are now over! I've spent the last months working on Shockwaves, a system that lets you show typed waveforms in (Surfer)[https://surfer-project.org/], and after many, *many* changes, tests, bug fixes and rewrites, we have finally reached the point of an official release!"
 toc: true
 mathjax: false
-# categories:
+categories:
+  - "News"
 #   - "Tutorial"
 tags:
   - "Shockwaves"


### PR DESCRIPTION
The "news" tab is awfully empty right now. @rowanG077 and I discussed it and figured we could merge them. This is pending a Team Clash discussion so please don't merge (also: it depends on https://github.com/clash-lang/clash-lang.org/pull/120).